### PR TITLE
Update `testingc.MC`: panic on fail

### DIFF
--- a/control.go
+++ b/control.go
@@ -21,12 +21,13 @@ const (
 
 type C struct {
 	testing.TB
-	smu       sync.Mutex
-	status    int8
-	cmu       sync.Mutex
-	cleanup   []func()
-	tmpDir    string
-	tmpDirSeq int32
+	smu         sync.Mutex
+	status      int8
+	cmu         sync.Mutex
+	cleanup     []func()
+	tmpDir      string
+	tmpDirSeq   int32
+	panicOnFail bool
 }
 
 func (c *C) Cleanup(f func()) {
@@ -60,6 +61,9 @@ func (c *C) Fail() {
 
 func (c *C) FailNow() {
 	c.Fail()
+	if c.panicOnFail {
+		panic("fail")
+	}
 	runtime.Goexit()
 }
 

--- a/testmain.go
+++ b/testmain.go
@@ -13,9 +13,16 @@ func (c *MC) Run() (code int) {
 	return c.m.Run()
 }
 
+func (c *MC) Name() string {
+	return "testingc.MC"
+}
+
 func M(m *testing.M, fn func(c *MC) int) int {
 	c := &MC{
 		m: m,
+		C: C{
+			panicOnFail: true,
+		},
 	}
 	done := make(chan int)
 


### PR DESCRIPTION
To make TestMain failed, FailNow must panic.